### PR TITLE
isBlankStructuredText PoC

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "test": "npm run lint && jest",
+    "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "publish": "npm run build && npm run test && lerna publish",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/contentful-to-structured-text/package-lock.json
+++ b/packages/contentful-to-structured-text/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "datocms-contentful-to-structured-text",
-			"version": "1.1.0-alpha.2",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@contentful/rich-text-types": "^14.1.2"

--- a/packages/html-to-structured-text/package-lock.json
+++ b/packages/html-to-structured-text/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "datocms-html-to-structured-text",
-			"version": "1.1.0-alpha.2",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"extend": "^3.0.2",
@@ -20,7 +20,8 @@
 				"unist-utils-core": "^1.0.5"
 			},
 			"devDependencies": {
-				"parse5": "^6.0.1"
+				"parse5": "^6.0.1",
+				"unist-util-inspect": "^6.0.0"
 			}
 		},
 		"node_modules/@types/hast": {
@@ -205,6 +206,16 @@
 				"unist-util-is": "^4.0.0"
 			}
 		},
+		"node_modules/unist-util-inspect": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-6.0.1.tgz",
+			"integrity": "sha512-odX3qLR7qhUnUYXsVClNNyiKftVcHDnd10fUBMmZekvyFS/M8toMsKhXQr7sW66NsFiEezQTCxX3M0dpGbfM3w==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/unist-util-is": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
@@ -302,11 +313,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
-		},
-		"array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
 		},
 		"boolbase": {
 			"version": "1.0.0",

--- a/packages/to-dom-nodes/package-lock.json
+++ b/packages/to-dom-nodes/package-lock.json
@@ -1,152 +1,108 @@
 {
-  "name": "datocms-structured-text-to-dom-nodes",
-  "version": "1.2.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "datocms-structured-text-to-dom-nodes",
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "datocms-structured-text-generic-html-renderer": "^1.1.1",
-        "datocms-structured-text-utils": "^1.1.1",
-        "hyperscript": "^2.0.2"
-      },
-      "devDependencies": {
-        "@types/hyperscript": "0.0.4"
-      }
-    },
-    "node_modules/@types/hyperscript": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hyperscript/-/hyperscript-0.0.4.tgz",
-      "integrity": "sha512-oZIYTxzfTYM6KNXwN3PPS5dow3KmjDcMDRF6iSxqidJSyw4kwo6yJlxrY/KrCc+0J14x0CflmZRApbcdLvwDiw==",
-      "dev": true
-    },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    },
-    "node_modules/browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
-    },
-    "node_modules/class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
-      "dependencies": {
-        "indexof": "0.0.1"
-      }
-    },
-    "node_modules/datocms-structured-text-generic-html-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-generic-html-renderer/-/datocms-structured-text-generic-html-renderer-1.1.1.tgz",
-      "integrity": "sha512-10LnFjOVp51N6fDUkvcVJmp87iah4pokI3jIDpAKucrT5kzvmv2xMpOuf/X5Nh8GLyXpGCBAKi2HbMxpWcNTgQ==",
-      "dependencies": {
-        "datocms-structured-text-utils": "^1.1.1"
-      }
-    },
-    "node_modules/datocms-structured-text-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-1.1.1.tgz",
-      "integrity": "sha512-Tdq0YnzxHK4t/i04LUlHL4mbKo6mKUw0/eWQs7/yLlEIAiRil7hrHOTL+esDFO+UGocpcG4qK42XFe3Blp4rQA==",
-      "dependencies": {
-        "array-flatten": "^3.0.0"
-      }
-    },
-    "node_modules/html-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
-      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
-      "dependencies": {
-        "class-list": "~0.1.1"
-      },
-      "engines": {
-        "node": ">=4.2"
-      }
-    },
-    "node_modules/hyperscript": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
-      "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
-      "dependencies": {
-        "browser-split": "0.0.0",
-        "class-list": "~0.1.0",
-        "html-element": "^2.0.0"
-      }
-    },
-    "node_modules/indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    }
-  },
-  "dependencies": {
-    "@types/hyperscript": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hyperscript/-/hyperscript-0.0.4.tgz",
-      "integrity": "sha512-oZIYTxzfTYM6KNXwN3PPS5dow3KmjDcMDRF6iSxqidJSyw4kwo6yJlxrY/KrCc+0J14x0CflmZRApbcdLvwDiw==",
-      "dev": true
-    },
-    "array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    },
-    "browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
-    },
-    "class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
-    },
-    "datocms-structured-text-generic-html-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-generic-html-renderer/-/datocms-structured-text-generic-html-renderer-1.1.1.tgz",
-      "integrity": "sha512-10LnFjOVp51N6fDUkvcVJmp87iah4pokI3jIDpAKucrT5kzvmv2xMpOuf/X5Nh8GLyXpGCBAKi2HbMxpWcNTgQ==",
-      "requires": {
-        "datocms-structured-text-utils": "^1.1.1"
-      }
-    },
-    "datocms-structured-text-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-1.1.1.tgz",
-      "integrity": "sha512-Tdq0YnzxHK4t/i04LUlHL4mbKo6mKUw0/eWQs7/yLlEIAiRil7hrHOTL+esDFO+UGocpcG4qK42XFe3Blp4rQA==",
-      "requires": {
-        "array-flatten": "^3.0.0"
-      }
-    },
-    "html-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
-      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
-      "requires": {
-        "class-list": "~0.1.1"
-      }
-    },
-    "hyperscript": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
-      "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
-      "requires": {
-        "browser-split": "0.0.0",
-        "class-list": "~0.1.0",
-        "html-element": "^2.0.0"
-      }
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    }
-  }
+	"name": "datocms-structured-text-to-dom-nodes",
+	"version": "1.2.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "datocms-structured-text-to-dom-nodes",
+			"version": "1.2.0",
+			"license": "MIT",
+			"dependencies": {
+				"hyperscript": "^2.0.2"
+			},
+			"devDependencies": {
+				"@types/hyperscript": "0.0.4"
+			}
+		},
+		"node_modules/@types/hyperscript": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hyperscript/-/hyperscript-0.0.4.tgz",
+			"integrity": "sha512-oZIYTxzfTYM6KNXwN3PPS5dow3KmjDcMDRF6iSxqidJSyw4kwo6yJlxrY/KrCc+0J14x0CflmZRApbcdLvwDiw==",
+			"dev": true
+		},
+		"node_modules/browser-split": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+			"integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+		},
+		"node_modules/class-list": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+			"integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+			"dependencies": {
+				"indexof": "0.0.1"
+			}
+		},
+		"node_modules/html-element": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+			"integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+			"dependencies": {
+				"class-list": "~0.1.1"
+			},
+			"engines": {
+				"node": ">=4.2"
+			}
+		},
+		"node_modules/hyperscript": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+			"integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+			"dependencies": {
+				"browser-split": "0.0.0",
+				"class-list": "~0.1.0",
+				"html-element": "^2.0.0"
+			}
+		},
+		"node_modules/indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+		}
+	},
+	"dependencies": {
+		"@types/hyperscript": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hyperscript/-/hyperscript-0.0.4.tgz",
+			"integrity": "sha512-oZIYTxzfTYM6KNXwN3PPS5dow3KmjDcMDRF6iSxqidJSyw4kwo6yJlxrY/KrCc+0J14x0CflmZRApbcdLvwDiw==",
+			"dev": true
+		},
+		"browser-split": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+			"integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+		},
+		"class-list": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+			"integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+			"requires": {
+				"indexof": "0.0.1"
+			}
+		},
+		"html-element": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
+			"integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
+			"requires": {
+				"class-list": "~0.1.1"
+			}
+		},
+		"hyperscript": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
+			"integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
+			"requires": {
+				"browser-split": "0.0.0",
+				"class-list": "~0.1.0",
+				"html-element": "^2.0.0"
+			}
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+		}
+	}
 }

--- a/packages/to-html-string/package-lock.json
+++ b/packages/to-html-string/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "datocms-structured-text-to-html-string",
-			"version": "1.1.0-alpha.2",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"vhtml": "^2.2.0"

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,28 +1,28 @@
 {
-  "name": "datocms-structured-text-utils",
-  "version": "1.2.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "datocms-structured-text-utils",
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "array-flatten": "^3.0.0"
-      }
-    },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    }
-  },
-  "dependencies": {
-    "array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-    }
-  }
+	"name": "datocms-structured-text-utils",
+	"version": "1.2.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "datocms-structured-text-utils",
+			"version": "1.2.0",
+			"license": "MIT",
+			"dependencies": {
+				"array-flatten": "^3.0.0"
+			}
+		},
+		"node_modules/array-flatten": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+		}
+	},
+	"dependencies": {
+		"array-flatten": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+		}
+	}
 }

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,28 +1,39 @@
 {
-	"name": "datocms-structured-text-utils",
-	"version": "1.2.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "datocms-structured-text-utils",
-			"version": "1.2.0",
-			"license": "MIT",
-			"dependencies": {
-				"array-flatten": "^3.0.0"
-			}
-		},
-		"node_modules/array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-		}
-	},
-	"dependencies": {
-		"array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-		}
-	}
+  "name": "datocms-structured-text-utils",
+  "version": "1.2.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datocms-structured-text-utils",
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^3.0.0",
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    }
+  },
+  "dependencies": {
+    "array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    }
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,8 @@
     "url": "https://github.com/datocms/structured-text/issues"
   },
   "dependencies": {
-    "array-flatten": "^3.0.0"
+    "array-flatten": "^3.0.0",
+    "fast-deep-equal": "^3.1.3"
   },
   "gitHead": "e2342d17a94ecb8d41538daef11face03d21d871"
 }

--- a/packages/utils/src/guards.ts
+++ b/packages/utils/src/guards.ts
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import {
   Root,
   List,
@@ -110,4 +111,32 @@ export function isDocument(
   obj: any,
 ): obj is Document {
   return obj && 'schema' in obj && 'document' in obj;
+}
+
+export const blankStructuredText = {
+  value: {
+    schema: 'dast',
+    document: {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'span',
+              value: '',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  blocks: [],
+};
+
+export function isBlankStructuredText<R extends Record>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  obj: any,
+): obj is StructuredText<R> {
+  return isStructuredText(obj.value) && deepEqual(blankStructuredText, obj);
 }


### PR DESCRIPTION
### The Problem

Structured Text content fields, as returned from the GraphQL API, could potentially yield `null` or a "blank" DAST structure which looks like this:

```js
{
  value: {
    schema: 'dast',
    document: {
      type: 'root',
      children: [
        {
          type: 'paragraph',
          children: [
            {
              type: 'span',
              value: '',
            },
          ],
        },
      ],
    },
  },
  blocks: [],
}
```

### Proposed Solution

Add a "guard" function to the set of existing Structured Text utils so we can deeply compare the equality of a given field (as returned from the GraphQL API) vs. this "blank" structure. 

```ts

const shouldRenderContent = structuredTextValue && !isBlankStructuredText(structuredTextValue) 

```

This can help developers decipher (beyond the `null` case) whether the content returned from these fields is usable. (i.e. for conditional rendering)
